### PR TITLE
Refactor Non Separated Digits Code Fix and Implement Separation Logic

### DIFF
--- a/src/Transpire.Analysis.Tests/LiteralNumberInformationTests.cs
+++ b/src/Transpire.Analysis.Tests/LiteralNumberInformationTests.cs
@@ -40,9 +40,6 @@ internal static class LiteralNumberInformationTests
 	[TestCase("344.1344e3", true)]
 	public static void ParseLiteralText(string value, bool needsSeparator)
 	{
-		static string GetCode(string literalText) =>
-			$"var value = {literalText};";
-
 		var information = new LiteralNumberInformation(LiteralNumberInformationTests.GetLiteralSyntax(GetCode(value)));
 
 		Assert.Multiple(() =>
@@ -52,6 +49,70 @@ internal static class LiteralNumberInformationTests
 		});
 	}
 
-	private static LiteralExpressionSyntax GetLiteralSyntax(string code) => 
+   [TestCase("12", 3u, "12")]
+   [TestCase("1234", 3u, "1_234")]
+	[TestCase("123L", 3u, "123L")]
+	[TestCase("1234L", 3u, "1_234L")]
+	[TestCase("4", 3u, "4")]
+   [TestCase("4123", 3u, "4_123")]
+   public static void CreateSeparated_FormatsIntegerLiteralsCorrectly(string value, uint spacingSize, string expected)
+		=> AssertSeparatedLiteral(value, spacingSize, expected);
+
+   [TestCase("0x12", 3u, "0x12")]
+   [TestCase("0x123", 2u, "0x1_23")]
+   [TestCase("0x14uL", 4u, "0x14uL")]
+   [TestCase("0x143uL", 2u, "0x1_43uL")]
+   [TestCase("0x1uL", 4u, "0x1uL")]
+   [TestCase("0x14L", 4u, "0x14L")]
+   [TestCase("0x1L", 4u, "0x1L")]
+   [TestCase("0x3d", 4u, "0x3d")]
+   public static void CreateSeparated_FormatsHexLiteralsCorrectly(string value, uint spacingSize, string expected)
+		=> AssertSeparatedLiteral(value, spacingSize, expected);
+
+   [TestCase("0b10", 4u, "0b10")]
+   [TestCase("0b1001", 4u, "0b1001")]
+   [TestCase("0b10L", 4u, "0b10L")]
+   [TestCase("0b1001L", 2u, "0b10_01L")]
+   [TestCase("0b10uL", 4u, "0b10uL")]
+   [TestCase("0b1001uL", 4u, "0b1001uL")]
+   public static void CreateSeparated_FormatsBinaryLiteralsCorrectly(string value, uint spacingSize, string expected)
+		=> AssertSeparatedLiteral(value, spacingSize, expected);
+
+   [TestCase("3d", 4u, "3d")]
+   [TestCase("3123d", 3u, "3_123d")]
+   public static void CreateSeparated_FormatsDoubleLiteralsCorrectly(string value, uint spacingSize, string expected)
+		=> AssertSeparatedLiteral(value, spacingSize, expected);
+
+   [TestCase("1e4", 3u, "1e4")]
+   [TestCase("1234e4", 3u, "1_234e4")]
+   [TestCase("14e10", 3u, "14e10")]
+   [TestCase("1443e10", 3u, "1_443e10")]
+   public static void CreateSeparated_FormatsExponentialLiteralsCorrectly(string value, uint spacingSize, string expected)
+		=> AssertSeparatedLiteral(value, spacingSize, expected);
+
+   [TestCase("3.4", 3u, "3.4")]
+   [TestCase("344.134", 3u, "344.134")]
+   [TestCase("3444.134", 3u, "3_444.134")]
+   [TestCase("344.1343", 3u, "344.1343")]
+   [TestCase("3.4e5", 3u, "3.4e5")]
+   [TestCase("344.134e3", 3u, "344.134e3")]
+   [TestCase("3444.134e3", 3u, "3_444.134e3")]
+   [TestCase("344.1344e3", 3u, "344.1344e3")]
+   public static void CreateSeparated_FormatsFloatingPointExponentialsCorrectly(string value, uint spacingSize, string expected)
+		=> AssertSeparatedLiteral(value, spacingSize, expected);
+
+   private static void AssertSeparatedLiteral(string value, uint spacingSize, string expected)
+	{
+		var information = new LiteralNumberInformation(GetLiteralSyntax(GetCode(value)));
+
+		var separated = information.CreateSeparated(spacingSize);
+		var actual = separated.ToString();
+		
+		Assert.That(actual, Is.EqualTo(expected));
+	}
+
+	private static string GetCode(string literalText) => $"var value = {literalText};";
+
+   private static LiteralExpressionSyntax GetLiteralSyntax(string code) =>
 		SyntaxFactory.ParseSyntaxTree(code).GetRoot().DescendantNodes(_ => true).OfType<LiteralExpressionSyntax>().Single();
 }

--- a/src/Transpire.Completions.Tests/DetectNonSeparatedDigitsCodeFixTests.cs
+++ b/src/Transpire.Completions.Tests/DetectNonSeparatedDigitsCodeFixTests.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using Transpire.Analysis;
+
+namespace Transpire.Completions.Tests;
+
+using Verify = CSharpCodeFixVerifier<DetectNonSeparatedDigitsAnalyzer, DetectNonSeparatedDigitsCodeFix, DefaultVerifier>;
+
+internal static class DetectNonSeparatedDigitsCodeFixTests
+{
+	[Test]
+	public static void VerifyGetFixableDiagnosticIds()
+	{
+		var fix = new DetectNonSeparatedDigitsCodeFix();
+		var ids = fix.FixableDiagnosticIds;
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(ids, Has.Length.EqualTo(1), nameof(ids.Length));
+			Assert.That(ids[0], Is.EqualTo(DescriptorIdentifiers.DetectNonSeparatedDigitsId), nameof(DescriptorIdentifiers.DetectNonSeparatedDigitsId));
+		});
+	}
+
+	[Test]
+	public static async Task VerifyGetDetectNonSeparatedDigitsCodeFixAsync()
+	{
+		var originalCode =
+			"""
+			public static class Test
+			{
+				public const int Value = [|3123|];
+
+				public static void Run() { }
+			}
+			""";
+		var fixedCode =
+			"""
+			public static class Test
+			{
+				public const int Value = [|3_123|];
+
+				public static void Run() { }
+			}
+			""";
+
+		await Verify.VerifyCodeFixAsync(originalCode, fixedCode);
+	}
+}

--- a/src/Transpire.Completions/DetectNonSeparatedDigitsCodeFix.cs
+++ b/src/Transpire.Completions/DetectNonSeparatedDigitsCodeFix.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Immutable;
 using System.Composition;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Transpire.Completions;
 
@@ -78,49 +77,7 @@ public sealed class DetectNonSeparatedDigitsCodeFix
 		Diagnostic diagnostic, string newLiteralText,
 		LiteralExpressionSyntax literalNode, string title)
 	{
-		var literalTokenType = literalNode.Token.GetType();
-		SyntaxToken newLiteralToken;
-
-		if (literalTokenType == typeof(int))
-		{
-			newLiteralToken = SyntaxFactory.Literal(
-				newLiteralText, (int)literalNode.Token.Value!);
-		}
-		else if (literalTokenType == typeof(uint))
-		{
-			newLiteralToken = SyntaxFactory.Literal(
-				newLiteralText, (uint)literalNode.Token.Value!);
-		}
-		else if (literalTokenType == typeof(long))
-		{
-			newLiteralToken = SyntaxFactory.Literal(
-				newLiteralText, (long)literalNode.Token.Value!);
-		}
-		else if (literalTokenType == typeof(ulong))
-		{
-			newLiteralToken = SyntaxFactory.Literal(
-				newLiteralText, (ulong)literalNode.Token.Value!);
-		}
-		else if (literalTokenType == typeof(float))
-		{
-			newLiteralToken = SyntaxFactory.Literal(
-				newLiteralText, (float)literalNode.Token.Value!);
-		}
-		else if (literalTokenType == typeof(double))
-		{
-			newLiteralToken = SyntaxFactory.Literal(
-				newLiteralText, (double)literalNode.Token.Value!);
-		}
-		else if (literalTokenType == typeof(decimal))
-		{
-			newLiteralToken = SyntaxFactory.Literal(
-				newLiteralText, (decimal)literalNode.Token.Value!);
-		}
-		else
-		{
-			throw new NotSupportedException($"The type {literalTokenType.Name} is not supported");
-		}
-
+		var newLiteralToken = SyntaxFactory.ParseToken(newLiteralText);
 		var newLiteralNode = SyntaxFactory.LiteralExpression(
 			SyntaxKind.NumericLiteralExpression, newLiteralToken);
 		var newRoot = root.ReplaceNode(literalNode, newLiteralNode);


### PR DESCRIPTION
Related to #22 

Sorry for the distraction during the stream earlier to make up for the lost time I have done the following:
- Replace `literalTokenType` conditionals with `SyntaxFactory.ParseToken(newLiteralText)`
- Implement `SeparateCharacters` method
- Add test for `DetectNonSeparatedDigitsCodeFix`