### PR TITLE
Fix InvalidCastException when DetectNonSeparatedDigitsCodeFix is recommended on an argument

### DIFF
--- a/src/Transpire.Completions.Tests/DetectNonSeparatedDigitsCodeFixTests.cs
+++ b/src/Transpire.Completions.Tests/DetectNonSeparatedDigitsCodeFixTests.cs
@@ -46,4 +46,35 @@ internal static class DetectNonSeparatedDigitsCodeFixTests
 
 		await Verify.VerifyCodeFixAsync(originalCode, fixedCode);
 	}
+
+	[Test]
+	public static async Task VerifyGetDetectNonSeparatedDigitsCodeFixWithinArgumentAsync()
+	{
+		var originalCode =
+			"""
+			public static class Test
+			{
+				public static void Caller()
+				{
+					Callee([|10000|]);
+				}
+			
+				public static void Callee(int value) { }
+			}
+			""";
+		var fixedCode =
+			"""
+			public static class Test
+			{
+				public static void Caller()
+				{
+					Callee([|10_000|]);
+				}
+			
+				public static void Callee(int value) { }
+			}
+			""";
+
+		await Verify.VerifyCodeFixAsync(originalCode, fixedCode);
+	}
 }

--- a/src/Transpire.Completions/DetectNonSeparatedDigitsCodeFix.cs
+++ b/src/Transpire.Completions/DetectNonSeparatedDigitsCodeFix.cs
@@ -47,7 +47,7 @@ public sealed class DetectNonSeparatedDigitsCodeFix
 
 		context.CancellationToken.ThrowIfCancellationRequested();
 
-		var literalNode = (LiteralExpressionSyntax)root.FindNode(diagnostic.Location.SourceSpan);
+		var literalNode = (LiteralExpressionSyntax)root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
 		var literalInformation = new LiteralNumberInformation(literalNode);
 
 		if (literalInformation.Prefix != string.Empty)


### PR DESCRIPTION
Saw this the other day but only got a chance to look at it now.
<img width="881" height="19" alt="Image" src="https://github.com/user-attachments/assets/1f3fb365-bd5e-4915-a51c-62d32433b238" />

```
System.InvalidCastException : Unable to cast object of type 'Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax' to type 'Microsoft.CodeAnalysis.CSharp.Syntax.LiteralExpressionSyntax'.
   at async Transpire.Completions.DetectNonSeparatedDigitsCodeFix.RegisterCodeFixesAsync(<Unknown Parameters>)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.CodeAnalysis.CodeFixes.CodeFixService.GetCodeFixesAsync(<Unknown Parameters>)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.CodeAnalysis.Extensions.IExtensionManagerExtensions.PerformFunctionAsync[T](<Unknown Parameters>)
```

When the `DetectNonSeparatedDigitsCodeFix` is recommended on an argument, `root.FindNode` doesn't get the inner `LiteralExpressionSyntax` by default so throws an exception. Needs to use `getInnermostNodeForTie: true` parameter to resolve

As shown below, the span is the same for both:
<img width="233" height="50" alt="image" src="https://github.com/user-attachments/assets/a400c591-103e-41d3-957d-ef75b702c71f" />
 
I've added a test to demonstrate but feel free to remove.